### PR TITLE
update consume events documentation

### DIFF
--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -87,6 +87,26 @@ finally:
     # Close the consumer
     consumer.close()
 ```
+### Register with the Lighthouse Developer Hub
+The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them. 
+
+To register with with the Hub:
+
+1. Create a file named `catalog-info.yaml` at the root of your source code repository. 
+2. Backstage offers a built in [System Entity Kind](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system). Populate your new `catalog-info.yaml` file with this template, updating `metadata` and `spec` with values that correspond to your system:
+ 
+        
+        apiVersion: backstage.io/v1alpha1
+        kind: System
+        metadata:
+          name: your system name
+          description: what the system does
+        spec:
+          owner: product team in charge of consuming system
+          domain: domain the system falls under
+        
+
+3. Once your `catalog-info.yaml` file has been committed, log into the [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) while on the VA network, and follow the [default Backstage provided method](https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog) for adding entries to the catalog. 
 
 ### Troubleshooting
 If you have questions or run into difficulties with any of these steps, please [contact the Enterprise Event Bus Team](get-support.md).


### PR DESCRIPTION
## Description 
[Original Ticket](https://app.zenhub.com/workspaces/event-bus-team-632b50a9a7bf8400277f2cf8/issues/gh/department-of-veterans-affairs/ves/747)

This pull request updates the Consume Events documentation on the event bus developer portal.