### PR TITLE
Updated consume events page

### DIFF
--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -2,25 +2,27 @@
 title: Consume Events
 ---
 # What’s a Consumer?
-A consumer is an application that is set up to receive messages or events in an event-driven system. The Event Bus exposes streams of events, called topics, to consumers. The events capture significant occurrences taking place in an external system. A list of currently available topics can be found in our [Event Catalog]. 
+A consumer is an application that is set up to receive messages or events in an event-driven system. The Event Bus exposes streams of events, called topics, to consumers. The events capture significant occurrences taking place in an external system. A list of currently available topics can be found in our [Event Catalog](https://department-of-veterans-affairs.github.io/ves-event-bus-developer-portal/use-events/).
 
-To access messages in a particular topic, an event consumer would subscribe to the topic and receive events as they occur in real time. This allows consumers to perform actions based on the event data, such as updating internal state, triggering other processes, etc. Learn more about the components and processes involved in event-based systems on our [Introduction to Event-Driven Architecture](link) page.
+To access messages in a particular topic, an event consumer would subscribe to the topic and receive events as they occur in real time. This allows consumers to perform actions based on the event data, such as updating internal state, triggering other processes, etc. Learn more about the components and processes involved in event-based systems on our [Introduction to Event-Driven Architecture](./intro-to-eda.md) page.
 
 ## Steps For Becoming a Consumer
 ### Find Events/Topics to Consume
-The first step to consuming an event is to [reach out to the Enterprise Event Bus Team](get-support.md) about your interest in events. From there, you can either subscribe to an existing topic with relevant events, or else identify a team able to provide the topic that is of interest to you. At this point in time, we are unable to identify producers for consumers that do not have a source for their desired events, but we will do our best to work with your chosen producing team. 
-See also our [Producer Onboarding](produce-events.md) page.
+The first step to consuming an event is to [reach out to the Enterprise Event Bus Team](./get-support.md) about your interest in events. From there, you can either subscribe to an existing topic with relevant events, or else identify a team able to provide the topic that is of interest to you. At this point in time, we are unable to identify producers for consumers that do not have a source for their desired events, but we will do our best to work with your chosen producing team.
+See also our [Produce Events](./produce-events.md) page.
 
 ### Determine If You Need an ESECC Request
-Depending on the location of a consumer application, you may need to obtain an ESECC (Enterprise Security External Change Council) request. The diagram below illustrates the relationship between consumer locations and ESECC requirements. It shows that as a general rule, consumers located within the VAEC (VA Enterprise Cloud) AWS Organization do not need to file an ESECC request. For consumers who are in other AWS organizations, or outside of AWS, an ESECC process will likely be needed. If you’re unsure which category your use case fits in, please reach out to the Event Bus Team for help. However, please also note that while the Event Bus Team is happy to give direction and assist with some aspects of the ESECC process, consumers are ultimately responsible for initiating and monitoring the request.
+Depending on the location of a consumer application, you may need to obtain an ESECC (Enterprise Security External Change Council) request. ESECC requests are required to open certain non-standard ports between different systems and allow traffic to flow over those ports.
 
-This [example documentation](https://github.com/department-of-veterans-affairs/checkin-devops/blob/master/docs/esecc-requests.md) provides a summary of the steps and processes involved in an ESECC request. Please be sure to get started as early as possible, as this can be a lengthy process.
+The diagram below illustrates the relationship between consumer locations and ESECC requirements. It shows that as a general rule, consumers located within the VAEC (VA Enterprise Cloud) AWS Organization do not need to file an ESECC request. For consumers who are in other AWS organizations, or outside of AWS, an ESECC process will likely be needed. If you’re unsure which category your use case fits in, please reach out to the Event Bus Team for help. However, please also note that while the Event Bus Team is happy to give direction and assist with some aspects of the ESECC process, consumers are ultimately responsible for initiating and monitoring the request.
+
+This [example documentation](https://github.com/department-of-veterans-affairs/checkin-devops/blob/master/docs/esecc-requests.md) provides a starting point that outlines the steps and processes involved in an ESECC request. Note that we have not verified that the document is complete and would be applicable in all situations. Please do your own research and be sure to get started as early as possible, as this can be a lengthy process.
 
 ![Client Environments ESECC Decision Circles](img/Client%20Environments%20ESECC%20Decision%20Circles.svg)
 ### Set up Authorization and Authentication
-To subscribe to specific topics on the Event Bus, consumers need to be authenticated and have the appropriate permissions. The Event Bus MSK cluster is only accessible from the VA Network, and we use AWS IAM (Identity and Access Management) Roles and Policies to control access to different resources. If your consuming application is within the AWS environment, you will need to let us know which IAM Role(s) or IAM User(s) we should grant access to, and set up the applicable IAM Policies on your end.
+To subscribe to specific topics on the Event Bus, consumers need to be authenticated and have the appropriate permissions. The Event Bus MSK cluster is only accessible from the VA Network, and we use AWS IAM (Identity and Access Management) Roles and Policies to control access to different resources. If your consuming application is within the AWS environment, you will need to let us know to which IAM Role(s) or IAM User(s) we should grant access. We will then set up the corresponding IAM Policies on our end and assign a named role for producers to authenticate with AWS MSK in their application code.
 
-If your consuming application is outside of the AWS environment, we will request an IAM User to be created on your behalf. You will then be able to access the requested topic(s) using those credentials. 
+If your consuming application is outside of the AWS environment, we will request an IAM User to be created on your behalf. You will then be able to access the requested topic(s) using those credentials.
 
 ### Connect to the Event Bus in the Development Environment
 Once the authentication and authorization steps have been completed, you will receive the Kafka bootstrap server addresses and port numbers with which you can connect to the Event Bus MSK cluster. The following ports are open for consumers and producers that are authenticated with AWS IAM:
@@ -28,65 +30,125 @@ Once the authentication and authorization steps have been completed, you will re
 - 9198 (for access from outside of AWS).
 
 ### Develop and Deploy Your Consumer Application
-Many programming languages and frameworks have libraries designed to interact with Kafka clusters. This allows consumer applications to be written in your language of choice. For reference, here is a Python example that consumes events from a topic called “appointments:”
+Many programming languages and frameworks offer libraries designed to interact with Kafka. To ensure full compatibility with the Event Bus, your code needs to authenticate with the AWS MSK cluster using the assigned role provided during the onboarding process. Additionally, consumers should reference the Confluent Schema Registry and use the appropriate schema to deserialize messages in Avro.
 
-```python
-from confluent_kafka import Consumer, KafkaException
-from confluent_kafka.admin import AdminClient, NewTopic
+See for instance this Java code that consumes messages from a topic named “test”:
 
-# Configuration
-bootstrap_servers = 'event_bus_msk_bootstrap_servers' # Replace with the MSK cluster's bootstrap servers
-topic_name = 'appointments' # Name of the topic to consume from
+???+ example
+    ```java
+        package com.eventbus.testconsumer;
 
-# IAM Role and AWS credentials
-aws_access_key_id = 'your_aws_access_key_id'
-aws_secret_access_key = 'your_aws_secret_access_key'
-aws_session_token = 'your_aws_session_token'  # Required for temporary credentials
+        import org.apache.avro.generic.GenericRecord;
+        import org.apache.kafka.clients.CommonClientConfigs;
+        import org.apache.kafka.clients.consumer.ConsumerConfig;
+        import org.apache.kafka.clients.consumer.ConsumerRecord;
+        import org.apache.kafka.clients.consumer.ConsumerRecords;
+        import org.apache.kafka.clients.consumer.KafkaConsumer;
+        import org.apache.kafka.common.config.SaslConfigs;
+        import org.apache.kafka.common.config.SslConfigs;
+        import org.slf4j.Logger;
+        import org.slf4j.LoggerFactory;
+        import java.util.concurrent.atomic.AtomicBoolean;
 
-# Configure the consumer
-conf = {
-    'bootstrap.servers': bootstrap_servers,
-    'security.protocol': 'SASL_SSL',
-    'sasl.mechanism': 'AWS_MSK_IAM',
-    'sasl.username': aws_access_key_id,
-    'sasl.password': aws_secret_access_key,
-    'sasl.aws_session_token': aws_session_token,
-    'group.id': 'your_consumer_group_id',
-    'auto.offset.reset': 'earliest',
-}
+        import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+        import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+        import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 
-# Create a Kafka consumer
-consumer = Consumer(conf)
+        import java.time.Duration;
+        import java.util.Collections;
+        import java.util.Properties;
+        import java.util.Map;
 
-# Subscribe to the topic
-consumer.subscribe([topic_name])
+        public class TestConsumer {
+            private static final Logger LOG = LoggerFactory.getLogger(TestConsumer.class);
+            private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
-# Consume events
-try:
-    while True:
-        msg = consumer.poll(1.0)  # Poll for new messages
-        if msg is None:
-            continue
-        if msg.error():
-            if msg.error().code() == KafkaException._PARTITION_EOF:
-                # Reached the end of a partition, handle as needed
-                continue
-            else:
-                # Handle other errors
-                print('Error occurred: {}'.format(msg.error().str()))
-                break
+            // Consumer values
 
-        # Process the consumed event
-        print('Received message: {}'.format(msg.value().decode('utf-8')))
+            // Set the topic you want to consume from
+            private static final String TOPIC = "test";
+            private static final String EB_BOOTSTRAP_SERVERS = System.getenv("EB_BOOTSTRAP_SERVERS");
+            private static final String EB_SECURITY_PROTOCOL = System.getenv("EB_SECURITY_PROTOCOL");
+            private static final String SCHEMA_REGISTRY_URL = System.getenv("SCHEMA_REGISTRY_URL");
+            private static final String AWS_ROLE = System.getenv("AWS_ROLE");
 
-except KeyboardInterrupt:
-    # Gracefully stop the consumer on keyboard interrupt
-    pass
+            private final KafkaConsumer<Long, GenericRecord> consumer;
 
-finally:
-    # Close the consumer
-    consumer.close()
-```
+            public TestConsumer() {
+                this.consumer = createConsumer();
+            }
+
+            public void run() {
+                try {
+                    // Configure properties for the KafkaAvroDeserializer
+                    Map<String, String> deserializerProps = Map.of(
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL,
+                        AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, TopicRecordNameStrategy.class.getName());
+
+                    // Create KafkaAvroDeserializer
+                    KafkaAvroDeserializer avroDeserializer = new KafkaAvroDeserializer();
+                    avroDeserializer.configure(deserializerProps, false);
+
+                    consumer.subscribe(Collections.singletonList(TOPIC));
+
+                    while (!shutdown.get()) {
+                        ConsumerRecords<Long, GenericRecord> records = consumer.poll(Duration.ofMillis(100));
+
+                        for (ConsumerRecord<Long, GenericRecord> record : records) {
+                            GenericRecord genericRecord = record.value();
+                            // Process the received Avro record
+                            LOG.info("Received record: {}", genericRecord.toString());
+                        }
+                    }
+                } catch (final WakeupException e) {
+                    // Ignore exception if shutting down
+                    if (!shutdown.get()) {
+                        throw e;
+                    }
+                } catch (final Exception e) {
+                    LOG.error("An exception occurred while consuming messages", e);
+                } finally {
+                    consumer.close();
+                }
+            }
+
+            /**
+            * Stops polling for new messages and wakes up the Kafka consumer.
+            */
+            public void shutdown() {
+                shutdown.set(true);
+                consumer.wakeup();
+            }
+
+            private KafkaConsumer<Long, GenericRecord> createConsumer() {
+                final Properties props = new Properties();
+
+                props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, EB_BOOTSTRAP_SERVERS);
+                props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+                props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+                props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-group"); // Set your consumer group ID
+
+                // Use SASL_SSL in production but PLAINTEXT in local environment
+                // w/docker_compose
+                if ("SASL_SSL".equals(EB_SECURITY_PROTOCOL)) {
+                    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, EB_SECURITY_PROTOCOL);
+                    props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/tmp/kafka.client.truststore.jks");
+                    props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
+                    props.put(SaslConfigs.SASL_MECHANISM, "AWS_MSK_IAM");
+                    props.put(SaslConfigs.SASL_JAAS_CONFIG,
+                            "software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn=\""
+                                    + AWS_ROLE // use the role name provided to you
+                                    + "\" awsStsRegion=\"us-gov-west-1\";");
+                    props.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+                            "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+                } else if (!"PLAINTEXT".equals(EB_SECURITY_PROTOCOL)) {
+                    LOG.error("Unknown EB_SECURITY_PROTOCOL '{}'", EB_SECURITY_PROTOCOL);
+                }
+
+                return new KafkaConsumer<>(props);
+            }
+        }
+    ```
 
 ### Logs
 
@@ -97,14 +159,14 @@ Datadog is a monitoring and analytics tool that is used within the VA and is hos
 Event bus logs can be found [here](https://lighthousedi.ddog-gov.com/logs?query=host%3A%22arn%3Aaws%3As3%3A%3A%3Aeventbus-msk-logs%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1684858340160&to_ts=1684859240160&live=true).
 
 ### Register with the Lighthouse Developer Hub
-The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them. 
+The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them.
 
 To register with with the Hub:
 
-1. Create a file named `catalog-info.yaml` at the root of your source code repository. 
+1. Create a file named `catalog-info.yaml` at the root of your source code repository.
 2. Backstage offers a built in [System Entity Kind](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system). Populate your new `catalog-info.yaml` file with this template, updating `metadata` and `spec` with values that correspond to your system:
- 
-        
+
+
         apiVersion: backstage.io/v1alpha1
         kind: System
         metadata:
@@ -113,9 +175,9 @@ To register with with the Hub:
         spec:
           owner: product team in charge of consuming system
           domain: domain the system falls under
-        
 
-3. Once your `catalog-info.yaml` file has been committed, log into the [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) while on the VA network, and follow the [default Backstage provided method](https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog) for adding entries to the catalog. 
+
+3. Once your `catalog-info.yaml` file has been committed, log into the [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) while on the VA network, and follow the [default Backstage provided method](https://backstage.io/docs/features/software-catalog/#adding-components-to-the-catalog) for adding entries to the catalog.
 
 ### Troubleshooting
 If you have questions or run into difficulties with any of these steps, please [contact the Enterprise Event Bus Team](get-support.md).

--- a/docs/produce-events.md
+++ b/docs/produce-events.md
@@ -72,11 +72,12 @@ See for instance this Java code that produces messages to a topic named â€œtestâ
     import org.slf4j.Logger;
     import org.slf4j.LoggerFactory;
 
-    import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+    import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
     import io.confluent.kafka.serializers.KafkaAvroSerializer;
     import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 
     import java.util.Properties;
+    import java.util.Map;
 
     public class TestProducer {
       private static final Logger LOG = LoggerFactory.getLogger(TestProducer.class);
@@ -86,6 +87,7 @@ See for instance this Java code that produces messages to a topic named â€œtestâ
       private static final String EB_BOOTSTRAP_SERVERS = System.getenv("EB_BOOTSTRAP_SERVERS");
       private static final String EB_SECURITY_PROTOCOL = System.getenv("EB_SECURITY_PROTOCOL");
       private static final String SCHEMA_REGISTRY_URL = System.getenv("SCHEMA_REGISTRY_URL");
+      private static final String AWS_ROLE = System.getenv("AWS_ROLE");
 
       private final KafkaProducer<Long, GenericRecord> producer;
 
@@ -96,10 +98,8 @@ See for instance this Java code that produces messages to a topic named â€œtestâ
       public void run() {
         try {
           // Configure properties for the KafkaAvroSerializer
-          Properties serializerProps = new Properties();
-          serializerProps.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
-          serializerProps.put(AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY,
-              TopicRecordNameStrategy.class.getName());
+          Map<String, String> serializerProps = Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL,
+          AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY,TopicRecordNameStrategy.class.getName());
 
           // Create KafkaAvroSerializer
           KafkaAvroSerializer avroSerializer = new KafkaAvroSerializer();
@@ -206,7 +206,7 @@ To register your topic with with the Hub:
     For the time being, `apiVersion` will have a constant, static value of `backstage.io/v1alpha1`, though we are most likely free to change this if we wish. Because we are introducing a new Entity Kind that doesn't exist in Backstage, any `Event` specification we validate against won't correspond to anything. [Read more here](https://backstage.io/docs/features/software-catalog/descriptor-format#apiversion-and-kind-required)
 
     #### kind [required]
-    This value must be set to `Event` in order to pass JSON schema validation. 
+    This value must be set to `Event` in order to pass JSON schema validation.
 
     #### metadata [required]
     A structure that contains information about the entity itself. For now, this will include three properties:


### PR DESCRIPTION
Updated consumer page to bring it in line with the producer page, as described in [this ticket](https://app.zenhub.com/workspaces/event-bus-team-632b50a9a7bf8400277f2cf8/issues/gh/department-of-veterans-affairs/ves/1060). 

Thanks to @kexbin for checking over the Java consumer code and helping me resolve several issues (I actually had to make some changes to the producer example code as well to make the samples match).