### PR TITLE
More fixes to code samples and added warning

### DIFF
--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -34,6 +34,9 @@ Many programming languages and frameworks offer libraries designed to interact w
 
 See for instance this Java code that consumes messages from a topic named “test”:
 
+!!! warning
+    Note that this code is a draft and might not run as it is. Once finalized, it will be accompanied by a comprehensive reference repo that can be set up locally for testing.
+
 ???+ example
     ```java
         package com.eventbus.testconsumer;
@@ -50,16 +53,15 @@ See for instance this Java code that consumes messages from a topic named “tes
         import org.slf4j.LoggerFactory;
         import java.util.concurrent.atomic.AtomicBoolean;
 
-        import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
         import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-        import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
+        import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 
         import java.time.Duration;
         import java.util.Collections;
         import java.util.Properties;
         import java.util.Map;
 
-        public class TestConsumer {
+        public class TestConsumer implements Runnable {
             private static final Logger LOG = LoggerFactory.getLogger(TestConsumer.class);
             private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
@@ -80,14 +82,6 @@ See for instance this Java code that consumes messages from a topic named “tes
 
             public void run() {
                 try {
-                    // Configure properties for the KafkaAvroDeserializer
-                    Map<String, String> deserializerProps = Map.of(
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL,
-                        AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, TopicRecordNameStrategy.class.getName());
-
-                    // Create KafkaAvroDeserializer
-                    KafkaAvroDeserializer avroDeserializer = new KafkaAvroDeserializer();
-                    avroDeserializer.configure(deserializerProps, false);
 
                     consumer.subscribe(Collections.singletonList(TOPIC));
 
@@ -126,6 +120,7 @@ See for instance this Java code that consumes messages from a topic named “tes
                 props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, EB_BOOTSTRAP_SERVERS);
                 props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
                 props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+                props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
                 props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-group"); // Set your consumer group ID
 
                 // Use SASL_SSL in production but PLAINTEXT in local environment
@@ -159,7 +154,7 @@ Datadog is a monitoring and analytics tool that is used within the VA and is hos
 Event bus logs can be found [here](https://lighthousedi.ddog-gov.com/logs?query=host%3A%22arn%3Aaws%3As3%3A%3A%3Aeventbus-msk-logs%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1684858340160&to_ts=1684859240160&live=true).
 
 ### Register with the Lighthouse Developer Hub
-The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them.
+The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across the VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them.
 
 To register with with the Hub:
 

--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -154,7 +154,7 @@ Datadog is a monitoring and analytics tool that is used within the VA and is hos
 Event bus logs can be found [here](https://lighthousedi.ddog-gov.com/logs?query=host%3A%22arn%3Aaws%3As3%3A%3A%3Aeventbus-msk-logs%22%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&stream_sort=desc&viz=stream&from_ts=1684858340160&to_ts=1684859240160&live=true).
 
 ### Register with the Lighthouse Developer Hub
-The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across the VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them.
+The [Lighthouse Developer Hub](https://hub.lighthouse.va.gov/) is a software catalog that houses entities from across VA. Once your consumer application is up and running, you'll want to register with the catalog so event producers are aware of how their events are being used, and which systems are consuming them.
 
 To register with with the Hub:
 

--- a/docs/produce-events.md
+++ b/docs/produce-events.md
@@ -54,6 +54,9 @@ Many programming languages and frameworks offer libraries designed to interact w
 
 See for instance this Java code that produces messages to a topic named “test”:
 
+!!! warning
+    Note that this code is a draft and might not run as it is. Once finalized, it will be accompanied by a comprehensive reference repo that can be set up locally for testing.
+
 ???+ example
 
     ```java
@@ -98,8 +101,7 @@ See for instance this Java code that produces messages to a topic named “test�
       public void run() {
         try {
           // Configure properties for the KafkaAvroSerializer
-          Map<String, String> serializerProps = Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL,
-          AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY,TopicRecordNameStrategy.class.getName());
+          Map<String, String> serializerProps = Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, SCHEMA_REGISTRY_URL);
 
           // Create KafkaAvroSerializer
           KafkaAvroSerializer avroSerializer = new KafkaAvroSerializer();


### PR DESCRIPTION
Made some more changes to the example code snippets and added warning that they are a draft. In followup ticket [#1076](https://app.zenhub.com/workspaces/event-bus-team-632b50a9a7bf8400277f2cf8/issues/gh/department-of-veterans-affairs/ves/1076) we will create some runnable code to validate the code samples.

cc @kexbin 