### PR TITLE
Chore: Enable attr_list extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ extra_css:
   - stylesheets/extra.css
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.superfences
 theme:


### PR DESCRIPTION
## Description

The PR does the following:

- Enables [attr_list](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists) extension in order to follow new syntax: `[link](url){:target="_blank"}`
- This was requested by the OSS team as they want redirect URLs to open in a different tab rather than same one when clicked on


## Testing

- Tested locally functionality