### PR TITLE
Update sample code to use OAUTHBEARER

### DIFF
--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -130,14 +130,13 @@ See for instance this Java code that consumes messages from a topic named “tes
                 if ("SASL_SSL".equals(EB_SECURITY_PROTOCOL)) {
                     props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, EB_SECURITY_PROTOCOL);
                     props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/tmp/kafka.client.truststore.jks");
-                    props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
-                    props.put(SaslConfigs.SASL_MECHANISM, "AWS_MSK_IAM");
+                    props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
                     props.put(SaslConfigs.SASL_JAAS_CONFIG,
-                            "software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn=\""
+                            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required awsRoleArn=\""
                                     + AWS_ROLE // use the role name provided to you
                                     + "\" awsStsRegion=\"us-gov-west-1\";");
-                    props.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
-                            "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+                    props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                            "software.amazon.msk.auth.iam.IAMOAuthBearerLoginCallbackHandler");
                 } else if (!"PLAINTEXT".equals(EB_SECURITY_PROTOCOL)) {
                     LOG.error("Unknown EB_SECURITY_PROTOCOL '{}'", EB_SECURITY_PROTOCOL);
                 }

--- a/docs/produce-events.md
+++ b/docs/produce-events.md
@@ -136,14 +136,13 @@ See for instance this Java code that produces messages to a topic named â€œtestâ
                 if ("SASL_SSL".equals(EB_SECURITY_PROTOCOL)) {
                     props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, EB_SECURITY_PROTOCOL);
                     props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/tmp/kafka.client.truststore.jks");
-                    props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
-                    props.put(SaslConfigs.SASL_MECHANISM, "AWS_MSK_IAM");
+                    props.put(SaslConfigs.SASL_MECHANISM, "OAUTHBEARER");
                     props.put(SaslConfigs.SASL_JAAS_CONFIG,
-                            "software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn=\""
+                            "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required awsRoleArn=\""
                                     + AWS_ROLE // use the role name provided to you
                                     + "\" awsStsRegion=\"us-gov-west-1\";");
-                    props.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
-                            "software.amazon.msk.auth.iam.IAMClientCallbackHandler");
+                    props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
+                            "software.amazon.msk.auth.iam.IAMOAuthBearerLoginCallbackHandler");
                 } else if (!"PLAINTEXT".equals(EB_SECURITY_PROTOCOL)) {
                     LOG.error("Unknown EB_SECURITY_PROTOCOL '{}'", EB_SECURITY_PROTOCOL);
                 }


### PR DESCRIPTION
### Part of ticket [2102](https://github.com/department-of-veterans-affairs/ves/issues/2102)

### Description
- Updated our sample code to use OAUTHBEARER instead of AWS_MSK_IAM, since this is no longer in alignment with our recommended [properties](https://github.com/department-of-veterans-affairs/VES/blob/master/research/Event%20Bus/Engineering/Kafka%20Properties.md)

I updated the sample code repo with the same changes in https://github.com/department-of-veterans-affairs/ves-event-bus-sample-code/pull/33