### PR TITLE
Fix Developer Portal Typo 2

### DIFF
--- a/docs/produce-events.md
+++ b/docs/produce-events.md
@@ -54,7 +54,7 @@ To produce messages to specific topics on the Event Bus, producers need to be au
 
 ### Connect to the Event Bus in the development environment
 
-Once the authentication and authorization steps have been completed, you will be able to connect to the the Event Bus MSK cluster using the Kafka bootstrap server addresses and port numbers available in the Event Catalog. The following ports are open for consumers and producers that are authenticated with AWS IAM:
+Once the authentication and authorization steps have been completed, you will be able to connect to the Event Bus MSK cluster using the Kafka bootstrap server addresses and port numbers available in the Event Catalog. The following ports are open for consumers and producers that are authenticated with AWS IAM:
 
 * 9098 (for access from AWS)
 * 9198 (for access from outside of AWS)


### PR DESCRIPTION
Change "the the" to "the" allowing David to step through this process again and clean up his notes for next time :-)