### PR TITLE
Add client properties documentation and ruby samples

### DIFF
--- a/docs/consume-events.md
+++ b/docs/consume-events.md
@@ -48,7 +48,7 @@ To connect to the Event Bus, consumers in **all programming languages** will nee
 
 | Property | Value | Description | Notes |
 | --- | --- | --- | --- |
-| [bootstrap.servers](https://kafka.apache.org/documentation/#consumerconfigs_bootstrap.servers) | List of one or more Event Bus brokers. This will vary depending on the environment (dev, prod, etc.). | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. | Only one of the Event Bus clusters needs to be included in this list, but including more than one will ensure the application can start up if one of the Kafka servers is down. |
+| [bootstrap.servers](https://kafka.apache.org/documentation/#consumerconfigs_bootstrap.servers) | List of one or more Event Bus brokers. This will vary depending on the environment (dev, prod, etc.). | A list of host/port pairs to use for establishing the initial connection to the Kafka cluster. | Only one of the Event Bus brokers needs to be included in this list, but including more than one will ensure the application can start up if one of the Kafka servers is down. |
 | [group.id](https://kafka.apache.org/documentation/#consumerconfigs_group.id) | This can be set to any value a consumer wants. | A unique string that identifies the consumer group this consumer belongs to. |  |
 | [sasl.mechanism](https://kafka.apache.org/documentation/#consumerconfigs_sasl.mechanism) | `OAUTHBEARER` | SASL mechanism used for client connections. |  |
 | [security.protocol](https://kafka.apache.org/documentation/#consumerconfigs_security.protocol) | `SASL_SSL` | Protocol used to communicate with brokers. |  |


### PR DESCRIPTION
### Issue

https://github.com/department-of-veterans-affairs/VES/issues/2033

### Notes

* Added sample code for a Ruby consumer and producer in a collapsed block. I also changed the Java samples to be collapsed by default, since visitors to the page may not be interested in looking at one over the other and it was creating a lot of vertical space. I can change these to be expanded by default if preferred.
* Added a section for required and recommended properties, copying over the details from [this standalone file](https://github.com/department-of-veterans-affairs/VES/blob/master/research/Event%20Bus/Engineering/Kafka%20Properties.md) in the VES repo. This was done to avoid having consumers and producers look in multiple places for necessary information.

### Testing

`mkdocs serve` - verified the pages render as expected