### PR TITLE
Re-enabled search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,6 @@ theme:
   icon:
     admonition:
       example: material/code-tags
-plugins: []
 nav:
   - 'Home': README.md
   - get-started.md


### PR DESCRIPTION
### Part of ticket [4226](https://github.com/department-of-veterans-affairs/ves/issues/4226)

### Description
- Adds _ Search bar back
- Fixes _ re-enables search. The fixes happened in upstream MkDocs repo

### Testing
- I tested these changes by _ Running locally and running axe dev tools accessibility tester as well as screen reader verification.
