### PR TITLE
Change CODEOWNERS to ves-event-bus team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in 
 # the repo. Unless a later match takes precedence,
-# @department-of-veterans-affairs/ves-event-bus-devs will be requested for
+# @department-of-veterans-affairs/ves-event-bus will be requested for
 # review when someone opens a pull request.
-* @department-of-veterans-affairs/ves-event-bus-devs
+* @department-of-veterans-affairs/ves-event-bus


### PR DESCRIPTION
### Unticketed

### Description
- We want [the whole team](https://github.com/orgs/department-of-veterans-affairs/teams/ves-event-bus) to be able to review and approve PRs for this repo
- FYI, that team has "write" level repo access (the default)

### Testing

