### PR TITLE
Update actions/cache version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/ves/issues/4477

### Description
- Fixes [error with deploy](https://github.com/department-of-veterans-affairs/ves-event-bus-developer-portal/actions/runs/13797685390) `This request has been automatically failed because it uses a deprecated version of actions/cache: v2.`

### Testing
- untested, a bug fix on a GHA
